### PR TITLE
Fix build with FFmpeg 8.0

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -244,7 +244,6 @@ static void VS_CC imageFileFree(void *instanceData, VSCore *core, const VSAPI *v
         for (auto &packet : sub.packets)
             av_packet_free(&packet);
 
-    avcodec_close(d->avctx);
     avcodec_free_context(&d->avctx);
 
     delete d;


### PR DESCRIPTION
See https://github.com/FFmpeg/FFmpeg/commit/0d48da2db0b239d80c6e8b30e66211a977566588

The deprecation comment for `avcodec_close()` said:
> Do not use this function. Use avcodec_free_context() to destroy a
> codec context (either open or closed). Opening and closing a codec context
> multiple times is not supported anymore -- use multiple codec contexts
> instead.

---

Should be backwards compatible with older FFmpeg as original `avcodec_free_context()` (https://github.com/FFmpeg/FFmpeg/commit/fd056029f45a9f6d213d9fce8165632042511d4f) internally ran `avcodec_close()`
```c
void avcodec_free_context(AVCodecContext **pavctx)
{
    AVCodecContext *avctx = *pavctx;

    if (!avctx)
        return;

    avcodec_close(avctx);
```